### PR TITLE
Added telldus link to the list of updated plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ As authors of the legacy accessories and platforms create new standalone plugins
 
 Here's what has been removed so far, along with a link to the replacement plugin:
 
+  * [telldus](https://github.com/johngson/homebridge-telldus)
   * [isy-js](https://github.com/rodtoll/homebridge-isy-js)
   * [KNX](https://github.com/snowdd1/homebridge-knx)
   * [Netatmo](https://github.com/planetk/homebridge-netatmo)


### PR DESCRIPTION
Hi, I've updated the telldus plugin to be compatible with the new homebred version and added it to the list of ported plugins. The plugin is not completely done but I will commit a update later today (november 11th) that will add all the old functionality.
