### PR TITLE
re-sync config-sample.json with reality

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -10,49 +10,12 @@
 
     "platforms": [
         {
-            "platform" : "Nest",
-            "name" : "Nest",
-            "username" : "username",
-            "password" : "password"
-        },
-        {
-            "platform" : "TelldusLive",
-            "name" : "Telldus Live!",
-            "public_key" : "telldus public key",
-            "private_key" : "telldus private key",
-            "token" : "telldus token",
-            "token_secret" : "telldus token secret"
-        },
-        {
-            "platform" : "Telldus",
-            "name" : "Telldus"
-        },
-        {
-            "platform": "Wink",
-            "name": "Wink",
-            "client_id": "YOUR_WINK_API_CLIENT_ID",
-            "client_secret": "YOUR_WINK_API_CLIENT_SECRET",
-            "username": "your@email.com",
-            "password": "WINK_PASSWORD"
-        },
-        {
-            "platform": "SmartThings",
-            "name": "SmartThings",
-            "app_id": "JSON SmartApp Id",
-            "access_token": "JSON SmartApp AccessToken"
-        },
-        {
             "platform": "Domoticz",
             "name": "Domoticz",
             "server": "127.0.0.1",
             "port": "8080",
             "roomid": 0,
             "loadscenes": 1
-        },
-        {
-            "platform": "PhilipsHue",
-            "name": "Phillips Hue",
-            "username": ""
         },
         {
             "platform": "ISY",
@@ -63,90 +26,34 @@
             "password": "password"
         },
         {
-            "platform": "LogitechHarmony",
-            "name": "Living Room Harmony Hub"
-        },
-        {
-            "platform": "Sonos",
-            "name": "Sonos",
-            "play_volume": 25
-        },
-        {
-            "platform": "YamahaAVR",
-            "play_volume": -35,
-            "setMainInputTo": "AirPlay" 
-        },
-        {
-            "platform": "ZWayServer",
-            "url": "http://192.168.1.10:8083/",
-            "login": "zwayusername",
-            "password": "zwayuserpassword",
-            "poll_interval": 2,
-            "split_services": false
-        },
-        {
-            "platform": "MiLight",
-            "name": "MiLight",
-            "ip_address": "255.255.255.255",
-            "port": 8899,
-            "type": "rgbw",
-            "delay": 30,
-            "repeat": 3,
-            "zones":["Kitchen Lamp","Bedroom Lamp","Living Room Lamp","Hallway Lamp"]
-        },
-        {
-             "platform": "HomeAssistant",
-             "name": "HomeAssistant",
-             "host": "http://192.168.1.10:8123",
-             "password": "XXXXX",
-             "supported_types": ["light", "switch", "media_player", "scene"]
-        },
-        {
             "platform": "LIFx",
             "name": "LIFx",
             "access_token": "XXXXXXXX generate at https://cloud.lifx.com/settings"
         },
         {
-            "platform": "Netatmo",
-            "name": "Netatmo Weather",
-            "auth": {
-                "client_id": "XXXXX Create at https://dev.netatmo.com/",
-                "client_secret": "XXXXX Create at https://dev.netatmo.com/",
-                "username": "your netatmo username",
-                "password": "your netatmo password"
-            }
+            "platform": "SmartThings",
+            "name": "SmartThings",
+            "app_id": "JSON SmartApp Id",
+            "access_token": "JSON SmartApp AccessToken"
         },
         {
-            "platform": "HomeMatic",
-            "name": "HomeMatic CCU",
-            "ccu_ip": "192.168.0.100",
-            "filter_device":[],
-            "filter_channel":["BidCos-RF.KEQXXXXXXX:4", "BidCos-RF.LEQXXXXXXX:2"],
-            "outlets":[ "BidCos-RF.KEQXXXXXXX:4","BidCos-RF.IEQXXXXXXX:1"]
-        },
+            "platform" : "TelldusLive",
+            "name" : "Telldus Live!",
+            "public_key" : "telldus public key",
+            "private_key" : "telldus private key",
+            "token" : "telldus token",
+            "token_secret" : "telldus token secret"
+        }
     ],
 
     "accessories": [
         {
-            "accessory": "WeMo",
-            "name": "Coffee Maker",
-            "description": "This shim supports Belkin WeMo devices on the same network as this server. You can create duplicate entries for this device and change the 'name' attribute to reflect what device is plugged into the WeMo, for instance 'Air Conditioner' or 'Coffee Maker'. This name will be used by Siri. Make sure to update the 'wemo_name' attribute with the EXACT name of the device in the WeMo app itself. This can be the same value as 'name' but it doesn't have to be.",
-            "wemo_name": "CoffeeMaker"
-        },
-        {
-            "accessory": "LiftMaster",
-            "name": "Garage Door",
-            "description": "This shim supports LiftMaster garage door openers that are already internet-connected to the 'MyQ' service.",
-            // "requiredDeviceId", "<ID of door if you have multiple doors, prompted by shim during startup if needed>",
-            "username": "your-liftmaster-username",
-            "password" : "your-liftmaster-password"
-        },
-        {
-            "accessory": "Lockitron",
-            "name": "Front Door",
-            "description": "This shim supports Lockitron locks. It uses the Lockitron cloud API, so the Lockitron must be 'awake' for locking and unlocking to actually happen. You can wake up Lockitron after issuing an lock/unlock command by knocking on the door.",
-            "lock_id": "your-lock-id",
-            "api_token" : "your-lockitron-api-access-token"
+            "accessory": "AD2USB",
+            "name": "Alarm",
+            "description": "Arm, disarm, and status monitoring of the default partition for Honeywell/Ademco alarm systems. Requires network configured AD2USB interface",
+            "host": "192.168.1.200", // IP address of the SER2SOCK service
+            "port" : 4999, // Port the SER2SOCK process is running on
+            "pin": "1234" // PIN used for arming / disarming
         },
         {
             "accessory": "Carwings",
@@ -155,27 +62,21 @@
             "username": "your-carwings-username",
             "password" : "your-carwings-password"
         },
-        {
-            "accessory": "iControl",
-            "name": "Xfinity Home",
-            "description": "This shim supports iControl-based security systems like Xfinity Home.",
-            "system": "XFINITY_HOME",
-            "email": "your-comcast-email",
-            "password": "your-comcast-password",
-            "pin": "your-security-system-pin-code"
+	{
+            "accessory": "ELKM1",
+            "name": "Security System",
+            "description": "Allows basic control of Elk M1 security system. You can use 1 of 3 arm modes: Away, Stay, Night. If you need to access all 3, create 3 accessories with different names.",
+            "zone": "1",
+            "host": "192.168.1.10",
+            "port": "2101",
+            "pin": "1234",
+            "arm": "Away"
         },
         {
             "accessory": "HomeMatic",
             "name": "Light",
             "description": "Control HomeMatic devices (The XMP-API addon for the CCU is required)",
             "ccu_id": "The XMP-API id of your HomeMatic device",
-            "ccu_ip": "The IP-Adress of your HomeMatic CCU device"
-        },
-        {
-            "accessory": "HomeMaticWindow",
-            "name": "Contact",
-            "description": "Control HomeMatic devices (The XMP-API addon for the CCU is required)",
-            "ccu_id": "The XMP-API id of your HomeMatic device (type HM-Sec-RHS)",
             "ccu_ip": "The IP-Adress of your HomeMatic CCU device"
         },
         {
@@ -190,26 +91,11 @@
             "ccu_ip": "The IP-Adress of your HomeMatic CCU device"
         },
         {
-            "accessory": "X10",
-            "name": "Lamp",
-            "ip_address": "localhost:3000",
-            "device_id": "E1",
-            "protocol": "pl",
-            "can_dim": true
-        },
-        {
-            "accessory": "Http",
-            "name": "Kitchen Lamp",
-            "on_url": "https://192.168.1.22:3030/devices/23222/on",
-            "on_body": "{\"state\":\"On\"}",
-            "off_url": "https://192.168.1.22:3030/devices/23222/off",
-            "off_body": "{\"state\":\"Off\"}",
-            "brightness_url": "https://192.168.1.22:3030/devices/23222/brightness/%b",
-			"username": "",
-			"password": "",
-            "http_method": "POST",
-			"service": "Switch",
-			"brightnessHandling": "no"
+            "accessory": "HomeMaticWindow",
+            "name": "Contact",
+            "description": "Control HomeMatic devices (The XMP-API addon for the CCU is required)",
+            "ccu_id": "The XMP-API id of your HomeMatic device (type HM-Sec-RHS)",
+            "ccu_ip": "The IP-Adress of your HomeMatic CCU device"
         },
 	{
             "accessory": "HttpHygrometer",
@@ -223,24 +109,6 @@
             "url": "http://home/URL",
             "http_method": "GET"
         },
-	{
-            "accessory": "ELKM1",
-            "name": "Security System",
-            "description": "Allows basic control of Elk M1 security system. You can use 1 of 3 arm modes: Away, Stay, Night. If you need to access all 3, create 3 accessories with different names.",
-            "zone": "1",
-            "host": "192.168.1.10",
-            "port": "2101",
-            "pin": "1234",
-            "arm": "Away"
-        },
-        {
-            "accessory": "AD2USB",
-            "name": "Alarm",
-            "description": "Arm, disarm, and status monitoring of the default partition for Honeywell/Ademco alarm systems. Requires network configured AD2USB interface",
-            "host": "192.168.1.200", // IP address of the SER2SOCK service
-            "port" : 4999, // Port the SER2SOCK process is running on
-            "pin": "1234" // PIN used for arming / disarming
-        },
         {
             "accessory": "Tesla",
             "name": "Tesla",
@@ -249,11 +117,12 @@
             "password" : "tesla_password"
         },
         {
-            "accessory": "Hyperion",
-            "name": "TV Backlight",
-            "description": "Control the Hyperion TV backlight server. https://github.com/tvdzwan/hyperion",
-            "host": "localhost", 
-            "port": "19444"
+            "accessory": "X10",
+            "name": "Lamp",
+            "ip_address": "localhost:3000",
+            "device_id": "E1",
+            "protocol": "pl",
+            "can_dim": true
         },
         {
             "accessory": "mpdclient",
@@ -261,26 +130,6 @@
             "host" : "localhost",
             "port" : 6600,
             "description": "Allows some control of an MPD server"
-        },
-        {
-            "accessory": "FileSensor",
-            "name": "File Time Motion Sensor",
-            "path": "/tmp/CameraDump/",
-            "window_seconds": 5,
-            "sensor_type": "m",
-            "inverse": false
-        },
-        {
-            "accessory": "GenericRS232Device",
-            "name": "Projector",
-            "description": "Make sure you set a 'Siri-Name' for your iOS-Device (example: 'Home Cinema') otherwise it might not work.",
-            "id": "TYDYMU044UVNP",
-            "baudrate": 9600,
-            "device": "/dev/tty.usbserial",
-            "manufacturer": "Acer",
-            "model_name": "H6510BD",
-            "on_command": "* 0 IR 001\r",
-            "off_command": "* 0 IR 002\r"
         }
     ]
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var api = require('./api')
+var api = require('./api');
 var fs = require('fs');
 
 module.exports = function(homebridge) {
@@ -15,7 +15,8 @@ module.exports = function(homebridge) {
     if (file.indexOf(".js") > 0) {
       var name = file.replace(".js","");
       homebridge.registerAccessory("homebridge-legacy-plugins", name, function(logger, config) {
-        console.log("Loading legacy accessory " + name);
+        if ((process.env.DEBUG) && (process.env.DEBUG.split(',').indexOf('homebridge') !== -1))
+          console.log("Loading legacy accessory " + name);
         
         var accessoryModule = require(path.join(accessoriesDir, file));
         return new accessoryModule.accessory(logger, config);
@@ -30,11 +31,12 @@ module.exports = function(homebridge) {
     if (file.indexOf(".js") > 0) {
       var name = file.replace(".js","");
       homebridge.registerPlatform("homebridge-legacy-plugins", name, function(logger, config) {
-        console.log("Loading legacy platform " + name);
-        
+        if ((process.env.DEBUG) && (process.env.DEBUG.split(',').indexOf('homebridge') !== -1))
+          console.log("Loading legacy platform " + name);
+
         var platformModule = require(path.join(platformsDir, file));
         return new platformModule.platform(logger, config);
       });
     }
   });
-}
+};


### PR DESCRIPTION
1a. many formerly legacy plugins now have their own repo, so remove their entries from `config-sample.json`
1b. re-arrange the remaining entries in `config-sample.json` to be alphabetical
2. and while we’re at it, fix the few things that `jshint` doesn’t appreciate
